### PR TITLE
[bugfix] Circle CI inferation failure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,4 @@ test:
   override:
     - yarn test
   post:
-    bash <(curl -s https://codecov.io/bash) -f coverage/*/lcovonly
+    - bash <(curl -s https://codecov.io/bash) -f coverage/*/lcovonly


### PR DESCRIPTION
Circle CI builds failed and got retired. This has been because of an invalid yaml configuration.

Example: [circleci/vknabel/status-bar-style/46](https://circleci.com/gh/vknabel/status-bar-style/46)